### PR TITLE
Fixed websocket auth to work with home-assistant 0.80 changes

### DIFF
--- a/remote_homeassistant.py
+++ b/remote_homeassistant.py
@@ -13,7 +13,7 @@ import aiohttp
 import voluptuous as vol
 
 from homeassistant.core import callback
-import homeassistant.components.websocket_api as api
+import homeassistant.components.websocket_api.auth as api
 from homeassistant.core import EventOrigin, split_entity_id
 from homeassistant.helpers.typing import HomeAssistantType, ConfigType
 from homeassistant.const import (CONF_HOST, CONF_PORT, EVENT_CALL_SERVICE,


### PR DESCRIPTION
Quick one-liner fix to work with home-assistant's modified websocket auth api in 0.80.