### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/remote_homeassistant/__init__.py
+++ b/custom_components/remote_homeassistant/__init__.py
@@ -383,7 +383,7 @@ class RemoteConnection(object):
                 entity_id = data['entity_id']
                 if not data['new_state']:
                     # entity was removed in the remote instance
-                    with suppress(ValueError, AttributeError):
+                    with suppress(ValueError, AttributeError, KeyError):
                         self._entities.remove(entity_id)
                     self._hass.states.async_remove(entity_id)
                     return


### PR DESCRIPTION
```ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved Traceback (most recent call last): File "/config/custom_components/remote_homeassistant/__init__.py", line 264, in _recv callback(message) File "/config/custom_components/remote_homeassistant/__init__.py", line 387, in fire_event self._entities.remove(entity_id) KeyError: 'persistent_notification.config_entry_discovery'```

Above error received when starting homekit component. Suppressing KeyError on line 386, in addition to those already suppressed seems to fix, but don't know what other tests should be run on this.

Ref: https://github.com/lukas-hetzenecker/home-assistant-remote/issues/23