### PR TITLE
Import YAML instances to config entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ remote_homeassistant:
     secure: true
     verify_ssl: false
     access_token: !secret access_token
-    api_password: !secret http_password
     entity_prefix: "instance02_"
     include:
       domains:
@@ -113,11 +112,7 @@ verify_ssl:
   type: bool
   default: true
 access_token:
-  description: Access token of the remote instance, if set. Mutually exclusive with api_password
-  required: false
-  type: string
-api_password:
-  description: DEPRECTAED! API password of the remote instance, if set. Mutually exclusive with access_token
+  description: Access token of the remote instance, if set.
   required: false
   type: string
 entity_prefix:

--- a/custom_components/remote_homeassistant/config_flow.py
+++ b/custom_components/remote_homeassistant/config_flow.py
@@ -153,10 +153,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, user_input):
         """Handle import from YAML."""
-        if CONF_ACCESS_TOKEN not in user_input:
-            _LOGGER.error(f"No access_token specified for {user_input[CONF_HOST]}")
-            return self.async_abort(reason="import_failed")
-
         try:
             info = await validate_input(self.hass, user_input)
         except Exception:

--- a/custom_components/remote_homeassistant/config_flow.py
+++ b/custom_components/remote_homeassistant/config_flow.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 
+from . import async_yaml_to_config_entry
 from .rest_api import ApiProblem, CannotConnect, InvalidAuth, async_get_discovery_info
 from .const import (
     CONF_REMOTE_CONNECTION,
@@ -159,31 +160,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.exception(f"import of {user_input[CONF_HOST]} failed")
             return self.async_abort(reason="import_failed")
 
-        conf = user_input.copy()
-        options = {}
-
-        if CONF_INCLUDE in conf:
-            include = conf.pop(CONF_INCLUDE)
-            if CONF_ENTITIES in include:
-                options[CONF_INCLUDE_ENTITIES] = include[CONF_ENTITIES]
-            if CONF_DOMAINS in include:
-                options[CONF_INCLUDE_DOMAINS] = include[CONF_DOMAINS]
-
-        if CONF_EXCLUDE in conf:
-            exclude = conf.pop(CONF_EXCLUDE)
-            if CONF_ENTITIES in exclude:
-                options[CONF_EXCLUDE_ENTITIES] = exclude[CONF_ENTITIES]
-            if CONF_DOMAINS in exclude:
-                options[CONF_EXCLUDE_DOMAINS] = exclude[CONF_DOMAINS]
-
-        if CONF_FILTER in conf:
-            options[CONF_FILTER] = conf.pop(CONF_FILTER)
-
-        if CONF_SUBSCRIBE_EVENTS in conf:
-            options[CONF_SUBSCRIBE_EVENTS] = conf.pop(CONF_SUBSCRIBE_EVENTS)
-
-        if CONF_ENTITY_PREFIX in conf:
-            options[CONF_ENTITY_PREFIX] = conf.pop(CONF_ENTITY_PREFIX)
+        conf, options = async_yaml_to_config_entry(user_input)
 
         # Options cannot be set here, so store them in a special key and import them
         # before setting up an entry

--- a/custom_components/remote_homeassistant/const.py
+++ b/custom_components/remote_homeassistant/const.py
@@ -2,6 +2,7 @@
 
 CONF_REMOTE_CONNECTION = "remote_connection"
 CONF_UNSUB_LISTENER = "unsub_listener"
+CONF_OPTIONS = "options"
 
 CONF_FILTER = "filter"
 CONF_SECURE = "secure"


### PR DESCRIPTION
This PR makes the following noteworthy changes:

* Instances defined in YAML are now imported to config entries. In order to do so, a connection must be made to the remote server in order to fetch its UUID as that is used as `unique_id`.
* `api_password` is now deprecated. Migrate to use `access_token` instead.
* The service `remote_homeassistant.reload` has been added that reloads the config from YAML, updates the corresponding config entry and reloads the integration. This basically reads and updates config from YAML without having to restart Home Assistant.

One note regarding config entries here is in place. Every time Home Assistant is started, the config in YAML is read and overwrites the config that is currently present in the config entries. This means that if something is changed via Options in the UI for an instance set up via YAML, the config will be reverted back to whatever is configured in YAML when Home Assistant is restarted. Options will only work as intended when setting up via config flow.

Honestly, this code isn't very well tested. So I would love it if someone wants to try it out.