### PR TITLE
Add option to load components present on remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ remote_homeassistant:
     - service_registered
     - zwave.network_ready
     - zwave.node_event
+    load_components:
+    - zwave
 ```
 
 ```
@@ -206,19 +208,27 @@ subscribe_events:
   default: 
   - state_changed
   - service_registered
+load_components:
+  description: Load components of specified domains only present on the remote instance, e.g. to register services that would otherwise not be available.
+  required: false
+  type: list
 ```
 
 ## Special notes 
 
-If you have remote domains (e.g. `switch`), that are not loaded on the master instance you need to add a dummy entry on the master, otherwise you'll get a `Call service failed` error.
+If you have remote domains (e.g. `switch`), that are not loaded on the master instance you need to list them under `load_components`, otherwise you'll get a `Call service failed` error.
 
 E.g. on the master:
 
 ```
-switch:
+remote_homeassistant:
+  instances:
+  - host: 10.0.0.2
+    load_components:
+    - zwave
 ```
 
-to enable all `switch` services.
+to enable all `zwave` services. This can also be configured via options under Configuration->Integrations.
 
 ---
 

--- a/custom_components/remote_homeassistant/config_flow.py
+++ b/custom_components/remote_homeassistant/config_flow.py
@@ -35,6 +35,7 @@ from .rest_api import (
 from .const import (
     CONF_REMOTE_CONNECTION,
     CONF_SECURE,
+    CONF_LOAD_COMPONENTS,
     CONF_FILTER,
     CONF_SUBSCRIBE_EVENTS,
     CONF_ENTITY_PREFIX,
@@ -196,6 +197,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             self.options = user_input.copy()
             return await self.async_step_domain_entity_filters()
 
+        domains, _ = self._domains_and_entities()
+        domains = set(domains + self.config_entry.options.get(CONF_LOAD_COMPONENTS, []))
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
@@ -207,7 +210,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                                 CONF_ENTITY_PREFIX
                             )
                         },
-                    ): str
+                    ): str,
+                    vol.Optional(
+                        CONF_LOAD_COMPONENTS,
+                        default=self._default(CONF_LOAD_COMPONENTS),
+                    ): cv.multi_select(sorted(domains)),
                 }
             ),
         )

--- a/custom_components/remote_homeassistant/const.py
+++ b/custom_components/remote_homeassistant/const.py
@@ -4,6 +4,7 @@ CONF_REMOTE_CONNECTION = "remote_connection"
 CONF_UNSUB_LISTENER = "unsub_listener"
 CONF_OPTIONS = "options"
 CONF_REMOTE_INFO = "remote_info"
+CONF_LOAD_COMPONENTS = "load_components"
 
 CONF_FILTER = "filter"
 CONF_SECURE = "secure"

--- a/custom_components/remote_homeassistant/translations/en.json
+++ b/custom_components/remote_homeassistant/translations/en.json
@@ -39,7 +39,8 @@
       "init": {
         "title": "Basic Options (step 1/4)",
         "data": {
-            "entity_prefix": "Entity prefix (optional)"
+            "entity_prefix": "Entity prefix (optional)",
+            "load_components": "Load component (if not loaded)"
         }
       },
       "domain_entity_filters": {


### PR DESCRIPTION
This simplifies loading of components that are only present on the remote instance a bit. Makes most sense when setting up via config flow as you don't have to make any YAML changes.

I made this an opt-in feature per component, so each components must be configured explicitly. The reason for this is that some integrations don't support loading with an empty config, as they yield an error when doing so.