### PR TITLE
Set up new endpoint for discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Platform | Description
 -- | --
 `remote_homeassistant` | Link multiple Home-Assistant instances together .
 
-The master instance connects to the Websocket APIs of the secondary instances (already enabled out of box), the connection options are specified via the `host`, `port`, and `secure` configuration parameters. If the secondary instance requires an access token to connect (created on the Profile page), it can be set via the `access_token` parameter. To ignore SSL warnings in secure mode, set the `verify_ssl` parameter to false.
+The main instance connects to the Websocket APIs of the remote instances (already enabled out of box), the connection options are specified via the `host`, `port`, and `secure` configuration parameters. If the remote instance requires an access token to connect (created on the Profile page), it can be set via the `access_token` parameter. To ignore SSL warnings in secure mode, set the `verify_ssl` parameter to false.
 
 After the connection is completed, the remote states get populated into the master instance.
 The entity ids can optionally be prefixed via the `entity_prefix` parameter.
 
-The component keeps track which objects originate from which instance. Whenever a service is called on an object, the call gets forwarded to the particular secondary instance.
+The component keeps track which objects originate from which instance. Whenever a service is called on an object, the call gets forwarded to the particular remote instance.
 
 When the connection to the remote instance is lost, all previously published states are removed again from the local state registry.
 
@@ -29,7 +29,7 @@ A possible use case for this is to be able to use different Z-Wave networks, on 
 
 ## Installation
 
-This component should be installed on the main instance of Home Assistant
+This component *must* be installed on both the main and remote instance of Home Assistant
 
 If you use HACS:
 
@@ -38,7 +38,18 @@ If you use HACS:
 Otherwise:
 
 1. To use this plugin, copy the `remote_homeassistant` folder into your [custom_components folder](https://developers.home-assistant.io/docs/creating_integration_file_structure/#where-home-assistant-looks-for-integrations).
-2. Add `remote_homeassistant:` to your HA configuration.
+
+
+**Remote instance**
+
+On the remote instance you also need to add this to `configuration.yaml`:
+
+```yaml
+remote_homeassistant:
+  instances:
+```
+
+This is not needed on the main instance.
 
 ## Configuration 
 
@@ -229,7 +240,7 @@ services:
 
 ### Missing Components
 
-If you have remote domains (e.g. `switch`), that are not loaded on the master instance you need to list them under `load_components`, otherwise you'll get a `Call service failed` error.
+If you have remote domains (e.g. `switch`), that are not loaded on the main instance you need to list them under `load_components`, otherwise you'll get a `Call service failed` error.
 
 E.g. on the master:
 

--- a/custom_components/remote_homeassistant/manifest.json
+++ b/custom_components/remote_homeassistant/manifest.json
@@ -3,7 +3,7 @@
   "name": "Remote Home-Assistant",
   "issue_tracker": "https://github.com/custom-components/remote_homeassistant/issues",
   "documentation": "https://github.com/custom-components/remote_homeassistant",
-  "dependencies": [],
+  "dependencies": ["http"],
   "config_flow": true,
   "codeowners": [
     "@lukas-hetzenecker",
@@ -13,6 +13,6 @@
   "zeroconf": [
     "_home-assistant._tcp.local."
   ],
-  "version": "3.4",
+  "version": "3.5",
   "iot_class": "local_push"
 }

--- a/custom_components/remote_homeassistant/proxy_services.py
+++ b/custom_components/remote_homeassistant/proxy_services.py
@@ -1,7 +1,7 @@
 """Support for proxy services."""
 import asyncio
-import voluptuous as vol
 
+import voluptuous as vol
 from homeassistant.core import SERVICE_CALL_LIMIT
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.service import SERVICE_DESCRIPTION_CACHE

--- a/custom_components/remote_homeassistant/sensor.py
+++ b/custom_components/remote_homeassistant/sensor.py
@@ -1,9 +1,9 @@
 """Sensor platform for connection status.."""
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_VERIFY_SSL
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import Entity
 
-from .const import CONF_SECURE, CONF_ENTITY_PREFIX
+from .const import CONF_ENTITY_PREFIX, CONF_SECURE
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/custom_components/remote_homeassistant/translations/en.json
+++ b/custom_components/remote_homeassistant/translations/en.json
@@ -17,7 +17,8 @@
       "cannot_connect": "Failed to connect to server",
       "invalid_auth": "Invalid credentials",
       "unsupported_version": "Unsupported version. At least version 0.111 is required.",
-      "unknown": "An unknown error occurred"
+      "unknown": "An unknown error occurred",
+      "missing_endpoint": "You need to install Remote Home Assistant on this host and add remote_homeassistant: to its configuration."
     },
     "abort": {
       "already_configured": "Already configured"


### PR DESCRIPTION
Since the /api/discovery_info endpoint has been deprecated, we lost a
way to retrieve a unique identifier from the remote instance. This
change introduces /api/remote_homeassistant/discovery containing the
information we are missing. The downside is that the component now must
be installed on the remote instance as well. The upside however is that
we now can add any new endpoint we need for additional features in the
future, which is good.

Fixes #133